### PR TITLE
correcting misspelled url module in blog/urls.py

### DIFF
--- a/blog/urls.py
+++ b/blog/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import urls
+from django.conf.urls import url
 from . import views
 
 urlpatterns = [


### PR DESCRIPTION
misspelling: 'urls' should be 'url'